### PR TITLE
Remove `gcc` dependency

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,7 @@ then
   SO_EXT='.dylib'
 else
   SO_EXT='.so'
+  export CXXFLAGS="${CXXFLAGS} -DBOOST_MATH_DISABLE_FLOAT128"
 fi
 
 mkdir -p build && cd build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha1: 9535120721b20a45460538f3ed8fa0f0fec1d797
 
 build:
-  number: 200
+  number: 201
   skip: true  # [py3k or win or osx]
   features:
     - blas_{{ variant }}
@@ -24,7 +24,6 @@ requirements:
     - cmake
     - swig
     - boost
-    - gcc  # [linux]
     - blas 1.1 {{ variant }}
     - openblas 0.2.18*
     - libxml2


### PR DESCRIPTION
We include an equivalent compiler in the docker image that we prefer to use; so, this should be removed. Also, when you do use `gcc`, please do include `libgcc` as well.